### PR TITLE
Allow specifying additional Hyperfoil controller arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,5 @@ tags
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 bin/*
 testbin/*
+
+vendor

--- a/api/v1alpha2/hyperfoil_types.go
+++ b/api/v1alpha2/hyperfoil_types.go
@@ -26,6 +26,9 @@ type HyperfoilSpec struct {
 	Image string `json:"image,omitempty"`
 	// Tag for controller image. Defaults to version matching the operator version.
 	Version string `json:"version,omitempty"`
+	// AdditionalArgs specifies additional arguments to pass to the Hyperfoil controller.
+	AdditionalArgs []string
+
 	// Specification of the exposed route.
 	Route RouteSpec `json:"route,omitempty"`
 	// Authentication/authorization settings.

--- a/controllers/hyperfoil_controller.go
+++ b/controllers/hyperfoil_controller.go
@@ -347,6 +347,8 @@ func controllerPod(cr *hyperfoilv1alpha2.Hyperfoil) *corev1.Pod {
 		"-Dio.hyperfoil.controller.external.uri=" + externalURI,
 		"-Dio.hyperfoil.rootdir=/var/hyperfoil/",
 	}
+	command = append(command, cr.Spec.AdditionalArgs...)
+
 	volumes := []corev1.Volume{}
 	volumeMounts := []corev1.VolumeMount{
 		{


### PR DESCRIPTION
As discussed in https://github.com/openshift-knative/eventing-hyperfoil-benchmark/issues/44
I need to specify additional arguments for the Hyperofoil
controller like `jgroups.thread_pool.max_threads`, etc.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>