### PR TITLE
Increase CPU limits for controller manager

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -48,7 +48,7 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 256Mi
           requests:
             cpu: 100m


### PR DESCRIPTION
I noticed that the controller manager takes a very long time
to start and it was in `ContainerCreating` for minutes sometimes.

By increasing the CPU limits to 500m is much faster to start.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>