### PR TITLE
Cleanup equality comparison by using DeepDerivative utility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/go-logr/logr v0.3.0
+	github.com/google/go-cmp v0.5.2 // indirect
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
 	github.com/openshift/api v0.0.0-20210329131242-b54945f3bcd8


### PR DESCRIPTION
Rather than creating custom comparison function based on
whatever is actually set by the controller, we can use
the generic `DeepDerivative` function by API machinery, which
is a generic function to compare the expected state with the
current state.

This would also make it easier to evolve the expected state
without forgetting about the associated comparison function

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>